### PR TITLE
feat: add api endpoint for form submission with validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:dev": "yarn run build:client:watch & yarn run build:server:watch",
     "build": "yarn clean && yarn build:client && yarn build:server",
     "clean": "rimraf dist",
+    "dev": "nodemon ./dist/server/server.js",
     "prebuild:dev": "yarn clean && yarn build:client",
     "release": "standard-version",
     "start": "node ./dist/server/server.js"
@@ -59,8 +60,10 @@
     "@babel/polyfill": "^7.8.3",
     "@babel/preset-react": "^7.8.3",
     "@babel/runtime": "^7.8.4",
+    "axios": "^0.19.2",
     "babel-loader": "^8.0.6",
     "babel-plugin-macros": "^2.8.0",
+    "body-parser": "^1.19.0",
     "bulma": "^0.8.0",
     "core-js": "^3.6.4",
     "css-loader": "^3.4.2",

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -3,6 +3,7 @@ import { Field, Form, Formik } from 'formik';
 import { useAppContext } from './AppContext';
 import validationSchema from './validationSchema';
 import TextInput from '@/components/text-input/TextInput';
+import axios from 'axios';
 import './Home.scss';
 
 const initialValues = {
@@ -25,8 +26,14 @@ const Home = () => {
 				validationSchema={validationSchema}
 				validateOnBlur={true}
 				onSubmit={(values, { setSubmitting }) => {
-					console.log('Submitted!');
-					console.log('values:', values);
+					axios({
+						method: 'post',
+						url: '/prequalify',
+						data: values
+					}).then(({ data, status }) => {
+						console.log('api response status:', status);
+						console.log('api response data:', data);
+					});
 				}}
 			>
 				{({ errors, isValid, touched, values }) => {

--- a/src/server/controllers/SubmissionController.js
+++ b/src/server/controllers/SubmissionController.js
@@ -1,0 +1,30 @@
+import { qualify, validateRequest } from '@/utils/validate';
+
+/**
+ * @function SubmissionController
+ * @description Main Express Controller
+ * @param {Object} req - Express request
+ * @param {Object} res - Express response
+ */
+const SubmissionController = (req, res) => {
+	const { price, make, model, income, creditScore } = req?.body || {};
+	const parsedData = {
+		price: Number(price),
+		make,
+		model,
+		income: Number(income),
+		creditScore: Number(creditScore)
+	};
+
+	const validRequest = validateRequest(parsedData);
+	const qualified = qualify(parsedData);
+
+	// send response
+	res.json({
+		...parsedData,
+		validRequest,
+		qualified
+	});
+};
+
+export default SubmissionController;

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -1,7 +1,10 @@
 import express from 'express';
 import HomeController from '@/server/controllers/HomeController';
+import SubmissionController from '@/server/controllers/SubmissionController';
 
 const router = express.Router();
+
+router.post('/prequalify', SubmissionController);
 
 router.get('/', HomeController);
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -2,6 +2,7 @@ import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import express from 'express';
 import router from './router';
+import bodyParser from 'body-parser';
 
 const server = express();
 const port = process.env.PORT || 4000;
@@ -10,6 +11,10 @@ const port = process.env.PORT || 4000;
 server.use(express.static('dist'));
 server.use(express.static('dist/client'));
 server.use(express.static('dist/server'));
+
+// Attach Middleware
+server.use(bodyParser.urlencoded({ extended: false }));
+server.use(bodyParser.json());
 
 server.use(router);
 

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -1,0 +1,31 @@
+/**
+ * @function validateRequest
+ * @description Validates submitted values for good/bad request. Returns true if validation passes.
+ * @param {Number} Object.price
+ * @param {String} Object.make
+ * @param {String} Object.model
+ * @param {Number} Object.income
+ * @param {Number} Object.creditScore
+ * @returns {Boolean}
+ */
+export const validateRequest = ({ price, make, model, income, creditScore }) =>
+	price > 0 &&
+	price <= 1000000 &&
+	make &&
+	typeof make === 'string' &&
+	model &&
+	typeof make === 'string' &&
+	income > 0 &&
+	creditScore >= 350 &&
+	creditScore <= 850;
+
+/**
+ * @function qualify
+ * @description Applies business rule to determine if submitted data qualifies for loan
+ * @param {Number} Object.price
+ * @param {Number} Object.income
+ * @param {Number} Object.creditScore
+ * @returns {Boolean}
+ */
+export const qualify = ({ price, income, creditScore }) =>
+	price <= income / 5 && creditScore >= 600;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,6 +56,9 @@ const getConfig = isServer => {
 			},
 			extensions: ['.js', '.json', '.jsx', '.scss'],
 			modules: ['node_modules']
+		},
+		watchOptions: {
+			ignored: /node_modules/
 		}
 	};
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1535,6 +1535,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 axobject-query@^2.0.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.1.2.tgz#2bdffc0371e643e5f03ba99065d5179b9ca79799"
@@ -1659,7 +1666,7 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
   integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
 
-body-parser@1.19.0:
+body-parser@1.19.0, body-parser@^1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
@@ -2734,6 +2741,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -3618,6 +3632,13 @@ fn-name@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
   integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This includes the following changes:

- Add '/prequalify' POST route to router.js
- Add SubmissionController for POST requests sent to /prequalify
- Add body-parser middleware to server.js to parse express request body
- Add Axios package for API calls
- Use Axios package on home page prequalification form to submit form data to /prequalify endpoint for validation and receive response
- Add validateRequest util to determine good/bad request
- Add qualify util to apply business rules to determine if form data qualifies for a loan